### PR TITLE
Add typescript declaration file gen support via pbts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,21 @@ module.exports = {
                  * default: false
                  */
                 json: true,
-                
+
                 /* import paths provided to pbjs.
                  * default: webpack import paths (i.e. config.resolve.modules)
                  */
                 paths: ['/path/to/definitions'],
-                
+
                 /* additional command line arguments passed to
                  * pbjs, see https://github.com/dcodeIO/ProtoBuf.js/#pbjs-for-javascript
                  * for a list of what's available.
                  * default: []
                  */
-                pbjsArgs: ['--no-encode']
+                pbjsArgs: ['--no-encode'],
+
+                /* Enable Typescript declaration file generation via pbts. */
+                pbts: false
               }
             }
         }]
@@ -58,7 +61,7 @@ module.exports = {
 // myModule.js
 
 /* replaces e.g.:
- * 
+ *
  *   const protobuf = require('protobufjs/light');
  *   const jsonDescriptor = require('json!my/compiled/protobuf.js');
  *   const Root = protobuf.Root.fromJSON(jsonDescriptor);


### PR DESCRIPTION
Your loader works excellently, but since I'm in a Typescript project I'd like to also automatically produce `.d.ts` files via protobufjs's `pbts` tool. I've added a flag to the options to enable that. If you're not interested in the PR, I can put it up as a separate module instead. If you have any other questions or requests, please let me know.

*NOTE*: I didn't include a version bump in the PR since I don't know if you have anything else you'd like to push along with it. I can squash that in if you'd prefer a cleaner history.