### PR TITLE
fix: normalize filename before comparing

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ module.exports = function protobufJsLoader(source) {
 
             if (fs.existsSync(resolved)) {
               // Don't add a dependency on the temp file
-              if (resolved !== filename) {
+              if (resolved !== protobuf.util.path.normalize(filename)) {
                 self.addDependency(resolved);
               }
               return resolved;


### PR DESCRIPTION
Without normalizing `filename`, I'm running into the following issue:

```output
resolved:  C:/Users/XXX/AppData/Local/Temp/tmp-25492-rZoK9byEw9Kc
filename:  C:\Users\XXX\AppData\Local\Temp\tmp-25492-rZoK9byEw9Kc
```

As the `resolved` variable is guaranteed to be normalized:

https://github.com/kmontag/protobufjs-loader/blob/e0b99a6af86b934dc82dce4f11cc3b4a4476efcf/index.js#L191-L198

`filename` must also be so.

My setup is:

- Node: v16.18.1
- Windows 10
- protobufjs: 7.1.2
- protobufjs-loader: 2.0.1

