### PR TITLE
feat: add option for custom typescript output locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ module.exports = {
              *
              * Declaration files will be written every time the loader runs.
              * By default, they'll be saved in the same directory as the
-             * protobuf file being processed, with a `.d.ts` extension.
+             * protobuf file being processed, using the same filename with a
+             * `.d.ts` extension.
              *
              * This only works if you're using the 'static-module' target
              * for pbjs (i.e. the default target).

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ module.exports = {
             /* Enable Typescript declaration file generation via pbts.
              *
              * Declaration files will be written every time the loader runs.
-             * They'll be saved in the same directory as the protobuf file
-             * being processed, with a `.d.ts` extension.
+             * By default, they'll be saved in the same directory as the
+             * protobuf file being processed, with a `.d.ts` extension.
              *
              * This only works if you're using the 'static-module' target
              * for pbjs (i.e. the default target).
@@ -63,6 +63,24 @@ module.exports = {
               /* Additional command line arguments passed to pbts.
                */
               args: ['--no-comments'],
+
+              /* Optional function which receives the path to a protobuf file,
+               * and returns the output path (or a promise resolving to the
+               * output path) for the associated Typescript declaration file.
+               *
+               * If this is null (i.e. by default), declaration files will be
+               * saved to `${protobufFile}.d.ts`.
+               *
+               * The loader won't create any directories on the filesystem. If
+               * writing to a nonstandard location, you should ensure that it
+               * exists and is writable.
+               *
+               * default: null
+               */
+              output: (protobufFile) =>
+                `/custom/location/${require('path').basename(
+                  protobufFile
+                )}.d.ts`,
             },
 
             /* Set the "target" flag to pbjs.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const { pbjs, pbts } = require('protobufjs-cli');
 const protobuf = require('protobufjs');
 const tmp = require('tmp');
@@ -33,6 +34,10 @@ const schema = {
               type: 'array',
               default: [],
             },
+            outDir: {
+              type: 'string',
+              default: ''
+            }
           },
           additionalProperties: false,
         },
@@ -49,7 +54,7 @@ const schema = {
  * properties (i.e. the user-provided object merged with default
  * values).
  *
- * @typedef {{ args: string[] }} PbtsOptions
+ * @typedef {{ args: string[], outDir: string }} PbtsOptions
  * @typedef {{
  *   paths: string[], pbjsArgs: string[],
  *   pbts: boolean | PbtsOptions,
@@ -70,6 +75,7 @@ const execPbts = (resourcePath, pbtsOptions, compiledContent, callback) => {
   /** @type PbtsOptions */
   const normalizedOptions = {
     args: [],
+    outDir: '',
     ...(pbtsOptions === true ? {} : pbtsOptions),
   };
 
@@ -98,7 +104,9 @@ const execPbts = (resourcePath, pbtsOptions, compiledContent, callback) => {
     )
     .then((compiledFilename) => {
       const declarationFilename = `${resourcePath}.d.ts`;
-      const pbtsArgs = ['-o', declarationFilename]
+      const absoluteDeclarationFilename = normalizedOptions.outDir !== '' ?
+        path.join(normalizedOptions.outDir, path.basename(declarationFilename)) : declarationFilename;
+      const pbtsArgs = ['-o', absoluteDeclarationFilename]
         .concat(normalizedOptions.args)
         .concat([compiledFilename]);
       pbts.main(pbtsArgs, (err) => {


### PR DESCRIPTION
This adds the `output` option to the `pbts` config, which accepts a function to map resource paths (i.e. protobuf file paths) to their typescript declaration (`.d.ts`) paths.

This is an alternate approach to https://github.com/kmontag/protobufjs-loader/pull/43.