### PR TITLE
build: convert tests to async/await syntax

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,16 +35,30 @@ const minify = (contents) => {
   return result.code;
 };
 
+/**
+ * Promisified glob function for convenience.
+ *
+ * @type { (globStr: string) => Promise<string[]> }
+ */
+const globPromise = (globStr) =>
+  new Promise((resolve, reject) => {
+    glob(globStr, (err, files) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(files);
+      }
+    });
+  });
+
 describe('protobufjs-loader', function () {
-  before(function (done) {
+  before(async function () {
     // The first time the compiler gets run (e.g. in a CI environment),
     // some additional packages will be installed in the
     // background. This can take awhile and trigger a timeout, so we do
     // it here explicitly first.
     this.timeout(10000);
-    compile('basic').then(() => {
-      done();
-    });
+    await compile('basic');
   });
 
   describe('with JSON / reflection', function () {
@@ -54,36 +68,30 @@ describe('protobufjs-loader', function () {
       };
     });
 
-    it('should compile to a JSON representation', function (done) {
-      compile('basic', this.opts).then(({ inspect }) => {
-        const contents = minify(inspect.arguments[0]);
-        const innerString =
-          'addJSON({foo:{nested:{Bar:{fields:{baz:{type:"string",id:1}}}}}})})';
-        assert.include(contents, innerString);
-        done();
-      });
+    it('should compile to a JSON representation', async function () {
+      const { inspect } = await compile('basic', this.opts);
+      const contents = minify(inspect.arguments[0]);
+      const innerString =
+        'addJSON({foo:{nested:{Bar:{fields:{baz:{type:"string",id:1}}}}}})})';
+      assert.include(contents, innerString);
     });
   });
 
   describe('with static code', function () {
-    it('should compile static code by default', function (done) {
-      compile('basic').then(({ inspect }) => {
-        const contents = minify(inspect.arguments[0]);
-        assert.include(contents, 'foo.Bar=function(){');
-        done();
-      });
+    it('should compile static code by default', async function () {
+      const { inspect } = await compile('basic');
+      const contents = minify(inspect.arguments[0]);
+      assert.include(contents, 'foo.Bar=function(){');
     });
 
-    it('should compile static code when the option is set explicitly', function (done) {
-      compile('basic', { target: 'static-module' }).then(({ inspect }) => {
-        const contents = minify(inspect.arguments[0]);
-        assert.include(contents, 'foo.Bar=function(){');
-        done();
-      });
+    it('should compile static code when the option is set explicitly', async function () {
+      const { inspect } = await compile('basic', { target: 'static-module' });
+      const contents = minify(inspect.arguments[0]);
+      assert.include(contents, 'foo.Bar=function(){');
     });
 
     describe('with typescript compilation', function () {
-      beforeEach(function (done) {
+      beforeEach(async function () {
         // Typescript generation requires that we write files directly
         // when the loader is invoked, rather than passing content
         // upstream to webpack for later assembly.
@@ -92,58 +100,67 @@ describe('protobufjs-loader', function () {
         // compiled definitions, we perform the compilation in a tmp
         // directory.
         const fixturesPath = path.resolve(__dirname, 'fixtures');
-        tmp.dir((err, tmpDir, cleanup) => {
-          if (err) {
-            throw err;
-          }
-
-          this.tmpDir = tmpDir;
-          this.cleanup = cleanup;
-
-          glob(path.join(fixturesPath, '**', '*.proto'), (globErr, files) => {
-            if (globErr) {
-              throw globErr;
+        const [tmpDir, cleanup] = await new Promise((resolve, reject) => {
+          tmp.dir((err, tmpDirResult, cleanupResult) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve([tmpDirResult, cleanupResult]);
             }
-            Promise.all(
-              files.map((file) => {
-                const targetPath = path.join(
-                  tmpDir,
-                  path.relative(fixturesPath, file)
-                );
-
-                return new Promise((resolve, reject) => {
-                  // Create subdirectories if necessary.
-                  fs.mkdir(
-                    path.dirname(targetPath),
-                    { recursive: true },
-                    (mkdirErr) => {
-                      if (mkdirErr) {
-                        reject(mkdirErr);
-                      } else {
-                        fs.copyFile(file, targetPath, (copyErr) => {
-                          if (copyErr) {
-                            reject(copyErr);
-                          } else {
-                            resolve(undefined);
-                          }
-                        });
-                      }
-                    }
-                  );
-                });
-              })
-            ).then(() => {
-              const target = path.resolve(__dirname, '..', 'node_modules');
-              const link = path.join(tmpDir, 'node_modules');
-              fs.symlink(target, link, (symlinkErr) => {
-                if (symlinkErr) {
-                  throw symlinkErr;
-                }
-                done();
-              });
-            });
           });
         });
+
+        this.tmpDir = tmpDir;
+        this.cleanup = cleanup;
+
+        const files = await globPromise(
+          path.join(fixturesPath, '**', '*.proto')
+        );
+
+        await Promise.all(
+          files.map((file) => {
+            const targetPath = path.join(
+              tmpDir,
+              path.relative(fixturesPath, file)
+            );
+
+            return new Promise((resolve, reject) => {
+              // Create subdirectories if necessary.
+              fs.mkdir(
+                path.dirname(targetPath),
+                { recursive: true },
+                (mkdirErr) => {
+                  if (mkdirErr) {
+                    reject(mkdirErr);
+                  } else {
+                    fs.copyFile(file, targetPath, (copyErr) => {
+                      if (copyErr) {
+                        reject(copyErr);
+                      } else {
+                        resolve(undefined);
+                      }
+                    });
+                  }
+                }
+              );
+            });
+          })
+        );
+        const target = path.resolve(__dirname, '..', 'node_modules');
+        const link = path.join(tmpDir, 'node_modules');
+
+        /** @type { Promise<void> } */
+        const symlinkNodeModulesPromise = new Promise((resolve, reject) => {
+          fs.symlink(target, link, (symlinkErr) => {
+            if (symlinkErr) {
+              reject(symlinkErr);
+            } else {
+              resolve();
+            }
+          });
+        });
+
+        await symlinkNodeModulesPromise;
       });
 
       afterEach(function () {
@@ -152,113 +169,102 @@ describe('protobufjs-loader', function () {
         }
       });
 
-      it('should not compile typescript by default', function (done) {
-        compile(path.join(this.tmpDir, 'basic')).then(() => {
-          glob(path.join(this.tmpDir, '*.d.ts'), (err, files) => {
-            if (err) {
-              throw err;
-            }
-            assert.equal(0, files.length);
-            done();
-          });
-        });
+      it('should not compile typescript by default', async function () {
+        await compile(path.join(this.tmpDir, 'basic'));
+        const files = await globPromise(path.join(this.tmpDir, '*.d.ts'));
+        assert.equal(0, files.length);
       });
 
-      it('should compile typescript when enabled', function (done) {
-        compile(path.join(this.tmpDir, 'basic'), { pbts: true }).then(() => {
-          // By default, definitions should just be siblings of their
-          // associated .proto file.
-          glob(path.join(this.tmpDir, '**', '*.d.ts'), (globErr, files) => {
-            if (globErr) {
-              throw globErr;
-            }
-            const expectedDefinitionsFile = path.join(
-              this.tmpDir,
-              'basic.proto.d.ts'
-            );
-            assert.sameMembers([expectedDefinitionsFile], files);
+      it('should compile typescript when enabled', async function () {
+        await compile(path.join(this.tmpDir, 'basic'), { pbts: true });
+        // By default, definitions should just be siblings of their
+        // associated .proto file.
+        const files = await globPromise(path.join(this.tmpDir, '**', '*.d.ts'));
+        const expectedDefinitionsFile = path.join(
+          this.tmpDir,
+          'basic.proto.d.ts'
+        );
+        assert.sameMembers([expectedDefinitionsFile], files);
 
-            fs.readFile(expectedDefinitionsFile, (readErr, content) => {
-              if (readErr) {
-                throw readErr;
-              }
-              const declarations = content.toString();
-              assert.include(declarations, 'public baz: string;');
-              assert.include(declarations, 'public static decodeDelimited');
-              done();
-            });
+        /** @type { string } */
+        const declarations = await new Promise((resolve, reject) => {
+          fs.readFile(expectedDefinitionsFile, (readErr, content) => {
+            if (readErr) {
+              reject(readErr);
+            } else {
+              resolve(content.toString());
+            }
           });
         });
+
+        assert.include(declarations, 'public baz: string;');
+        assert.include(declarations, 'public static decodeDelimited');
       });
 
-      it('should compile nearly-empty declarations if typescript compilation is enabled for JSON output', function (done) {
-        compile(path.join(this.tmpDir, 'basic'), {
+      it('should compile nearly-empty declarations if typescript compilation is enabled for JSON output', async function () {
+        await compile(path.join(this.tmpDir, 'basic'), {
           target: 'json-module',
           pbts: true,
-        }).then(() => {
-          glob(path.join(this.tmpDir, '*.d.ts'), (err, files) => {
-            if (err) {
-              throw err;
+        });
+        const files = await globPromise(path.join(this.tmpDir, '*.d.ts'));
+
+        const expectedDefinitionsFile = path.join(
+          this.tmpDir,
+          'basic.proto.d.ts'
+        );
+        assert.sameMembers([expectedDefinitionsFile], files);
+
+        /** @type { string } */
+        const declarations = await new Promise((resolve, reject) => {
+          fs.readFile(expectedDefinitionsFile, (readErr, content) => {
+            if (readErr) {
+              reject(readErr);
+            } else {
+              resolve(content.toString());
             }
-
-            const expectedDefinitionsFile = path.join(
-              this.tmpDir,
-              'basic.proto.d.ts'
-            );
-            assert.sameMembers([expectedDefinitionsFile], files);
-
-            fs.readFile(expectedDefinitionsFile, (readErr, content) => {
-              if (readErr) {
-                throw readErr;
-              }
-              const declarations = content.toString();
-              // Make sure the main protobufjs import shows up.
-              assert.include(
-                declarations,
-                'import * as $protobuf from "protobufjs";'
-              );
-              // Some versions of protobufjs-cli will also include
-              // additional imports. Make sure all non-empty lines are
-              // imports.
-              declarations.split('\n').forEach((line) => {
-                if (line.trim().length !== 0) {
-                  assert.include(line, 'import');
-                }
-              });
-              done();
-            });
           });
+        });
+
+        // Make sure the main protobufjs import shows up.
+        assert.include(
+          declarations,
+          'import * as $protobuf from "protobufjs";'
+        );
+        // Some versions of protobufjs-cli will also include
+        // additional imports. Make sure all non-empty lines are
+        // imports.
+        declarations.split('\n').forEach((line) => {
+          if (line.trim().length !== 0) {
+            assert.include(line, 'import');
+          }
         });
       });
 
-      it('should pass arguments to pbts', function (done) {
-        compile(path.join(this.tmpDir, 'basic'), {
+      it('should pass arguments to pbts', async function () {
+        await compile(path.join(this.tmpDir, 'basic'), {
           pbts: {
             args: ['-n', 'testModuleName'],
           },
-        }).then(() => {
-          glob(path.join(this.tmpDir, '*.d.ts'), (globErr, files) => {
-            if (globErr) {
-              throw globErr;
-            }
-            const expectedDeclarationFile = path.join(
-              this.tmpDir,
-              'basic.proto.d.ts'
-            );
-            assert.sameMembers([expectedDeclarationFile], files);
+        });
+        const files = await globPromise(path.join(this.tmpDir, '*.d.ts'));
+        const expectedDeclarationFile = path.join(
+          this.tmpDir,
+          'basic.proto.d.ts'
+        );
+        assert.sameMembers([expectedDeclarationFile], files);
 
-            fs.readFile(expectedDeclarationFile, (readErr, content) => {
-              if (readErr) {
-                throw readErr;
-              }
-              const declarations = content.toString();
-              assert.include(declarations, 'public baz: string;');
-              assert.include(declarations, 'public static decodeDelimited');
-              assert.include(declarations, 'declare namespace testModuleName');
-              done();
-            });
+        const declarations = await new Promise((resolve, reject) => {
+          fs.readFile(expectedDeclarationFile, (readErr, content) => {
+            if (readErr) {
+              reject(readErr);
+            } else {
+              resolve(content.toString());
+            }
           });
         });
+        assert.include(declarations, 'public baz: string;');
+        assert.include(declarations, 'public static decodeDelimited');
+        assert.include(declarations, 'declare namespace testModuleName');
       });
 
       describe('with custom declaration output locations', function () {
@@ -341,73 +347,71 @@ describe('protobufjs-loader', function () {
       });
 
       describe('with imports', function () {
-        it('should compile imported definitions', function (done) {
-          compile(path.join(this.tmpDir, 'import'), {
+        it('should compile imported definitions', async function () {
+          await compile(path.join(this.tmpDir, 'import'), {
             paths: [this.tmpDir],
             pbts: true,
-          }).then(() => {
-            glob(path.join(this.tmpDir, '**', '*.d.ts'), (globErr, files) => {
-              if (globErr) {
-                throw globErr;
+          });
+          const files = await globPromise(
+            path.join(this.tmpDir, '**', '*.d.ts')
+          );
+          const expectedDeclarationFile = path.join(
+            this.tmpDir,
+            'import.proto.d.ts'
+          );
+          assert.sameMembers([expectedDeclarationFile], files);
+
+          /** @type { string } */
+          const declarations = await new Promise((resolve, reject) => {
+            fs.readFile(expectedDeclarationFile, (readErr, content) => {
+              if (readErr) {
+                reject(readErr);
+              } else {
+                resolve(content.toString());
               }
-              const expectedDeclarationFile = path.join(
-                this.tmpDir,
-                'import.proto.d.ts'
-              );
-              assert.sameMembers([expectedDeclarationFile], files);
-
-              fs.readFile(expectedDeclarationFile, (readErr, content) => {
-                if (readErr) {
-                  throw readErr;
-                }
-                const declarations = content.toString();
-
-                // Check that declarations from the top-level `import`
-                // fixture are present.
-                assert.include(
-                  declarations,
-                  'class NotBar implements INotBar {'
-                );
-
-                // Check that declarations from the imported `basic`
-                // fixture are present.
-                assert.include(declarations, 'class Bar implements IBar');
-
-                // Check that declarations imported from the
-                // subdirectory are present.
-                assert.include(declarations, 'class Baz implements IBaz');
-                assert.include(declarations, 'namespace sub');
-
-                done();
-              });
             });
           });
+
+          // Check that declarations from the top-level `import`
+          // fixture are present.
+          assert.include(declarations, 'class NotBar implements INotBar {');
+
+          // Check that declarations from the imported `basic`
+          // fixture are present.
+          assert.include(declarations, 'class Bar implements IBar');
+
+          // Check that declarations imported from the
+          // subdirectory are present.
+          assert.include(declarations, 'class Baz implements IBaz');
+          assert.include(declarations, 'namespace sub');
         });
       });
     });
   });
 
   describe('with an invalid protobuf file', function () {
-    it('should throw a compilation error', function (done) {
-      compile('invalid').catch((err) => {
+    it('should throw a compilation error', async function () {
+      let didError = false;
+      try {
+        await compile('invalid');
+      } catch (err) {
+        didError = true;
         assert.include(`${err}`, "illegal token 'invalid'");
-        done();
-      });
+      }
+      assert.isTrue(didError);
     });
   });
 
   describe('with command line options', function () {
-    it('should pass command line options to the pbjs call', function (done) {
-      compile('basic', { pbjsArgs: ['--no-encode'] }).then(({ inspect }) => {
-        const contents = minify(inspect.arguments[0]);
+    it('should pass command line options to the pbjs call', async function () {
+      const { inspect } = await compile('basic', { pbjsArgs: ['--no-encode'] });
+      const contents = minify(inspect.arguments[0]);
 
-        // Sanity check
-        const innerString = 'Bar.decode=function decode(reader,length)';
-        assert.include(contents, innerString);
+      // Sanity check
+      const innerString = 'Bar.decode=function decode(reader,length)';
+      assert.include(contents, innerString);
 
-        assert.notInclude(contents, 'encode');
-        done();
-      });
+      assert.notInclude(contents, 'encode');
     });
   });
 
@@ -417,9 +421,9 @@ describe('protobufjs-loader', function () {
         '.addJSON({foo:{nested:{NotBar:{fields:{bar:{type:"Bar",id:1}}},Bar:{fields:{baz:{type:"string",id:1}}},sub:{nested:{Baz:{fields:{id:{type:"int32",id:1}}}}}}}})});';
     });
 
-    it('should respect the webpack paths configuration', function (done) {
+    it('should respect the webpack paths configuration', async function () {
       const { innerString } = this;
-      compile(
+      const { inspect } = await compile(
         'import',
         {
           target: 'json-module',
@@ -429,66 +433,68 @@ describe('protobufjs-loader', function () {
             modules: ['node_modules', path.resolve(__dirname, 'fixtures')],
           },
         }
-      ).then(({ inspect }) => {
-        const contents = minify(inspect.arguments[0]);
-        assert.include(contents, innerString);
-        done();
-      });
+      );
+      const contents = minify(inspect.arguments[0]);
+      assert.include(contents, innerString);
     });
 
-    it('should respect an explicit paths configuration', function (done) {
+    it('should respect an explicit paths configuration', async function () {
       const { innerString } = this;
-      compile('import', {
+      const { inspect } = await compile('import', {
         target: 'json-module',
         paths: [path.resolve(__dirname, 'fixtures')],
-      }).then(({ inspect }) => {
-        const contents = minify(inspect.arguments[0]);
-        assert.include(contents, innerString);
-        done();
       });
+      const contents = minify(inspect.arguments[0]);
+      assert.include(contents, innerString);
     });
 
-    it('should add the imports as dependencies', function (done) {
-      compile('import', { paths: [path.resolve(__dirname, 'fixtures')] }).then(
-        ({ inspect }) => {
-          assert.include(
-            // This method is missing from the typings for older webpack
-            // versions, but it's supported in practice. If we drop
-            // support for v4 and below, we can remove this.
-            //
-            // @ts-ignore
-            inspect.context.getDependencies(),
-            path.resolve(__dirname, 'fixtures', 'basic.proto')
-          );
-          done();
-        }
-      );
+    it('should add the imports as dependencies', async function () {
+      const { inspect } = await compile('import', {
+        paths: [path.resolve(__dirname, 'fixtures')],
+      });
+
+      assert.sameMembers(inspect.context.getDependencies(), [
+        // The main proto file should be included.
+        path.resolve(__dirname, 'fixtures', 'import.proto'),
+
+        // Imported files should also be included.
+        path.resolve(__dirname, 'fixtures', 'basic.proto'),
+        path.resolve(__dirname, 'fixtures', 'sub', 'baz.proto'),
+      ]);
     });
 
-    it('should fail when the import is not found', function (done) {
-      compile('import', {
-        target: 'json-module',
-        // No include paths provided, so the 'import' fixture should
-        // fail to compile.
-      }).catch((err) => {
+    it('should fail when the import is not found', async function () {
+      let didError = false;
+      try {
+        await compile('import', {
+          target: 'json-module',
+          // No include paths provided, so the 'import' fixture should
+          // fail to compile.
+        });
+      } catch (err) {
+        didError = true;
         // The exact error that comes back from protobufjs differs
         // depending on the package version, so we have to just check
         // the webpack-specific portion of the error message.
         assert.include(`${err}`, 'ModuleBuildError: Module build failed');
-        done();
-      });
+      }
+      assert.isTrue(didError);
     });
   });
 
   describe('with invalid options', function () {
-    it('should fail if unrecognized properties are added', function (done) {
-      compile('basic', {
-        target: 'json-module',
-        foo: true,
-      }).catch((err) => {
+    it('should fail if unrecognized properties are added', async function () {
+      let didError = false;
+      try {
+        await compile('basic', {
+          target: 'json-module',
+          foo: true,
+        });
+      } catch (err) {
+        didError = true;
         assert.include(`${err}`, "configuration has an unknown property 'foo'");
-        done();
-      });
+      }
+      assert.isTrue(didError);
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -51,6 +51,22 @@ const globPromise = (globStr) =>
     });
   });
 
+/**
+ * Promisified read-file-as-string function for convenience.
+ *
+ * @type { (path: string | fs.PathLike) => Promise<string> }
+ */
+const readFileAsString = (path) =>
+  new Promise((resolve, reject) => {
+    fs.readFile(path, (err, content) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(content.toString());
+      }
+    });
+  });
+
 describe('protobufjs-loader', function () {
   before(async function () {
     // The first time the compiler gets run (e.g. in a CI environment),
@@ -186,16 +202,7 @@ describe('protobufjs-loader', function () {
         );
         assert.sameMembers([expectedDefinitionsFile], files);
 
-        /** @type { string } */
-        const declarations = await new Promise((resolve, reject) => {
-          fs.readFile(expectedDefinitionsFile, (readErr, content) => {
-            if (readErr) {
-              reject(readErr);
-            } else {
-              resolve(content.toString());
-            }
-          });
-        });
+        const declarations = await readFileAsString(expectedDefinitionsFile);
 
         assert.include(declarations, 'public baz: string;');
         assert.include(declarations, 'public static decodeDelimited');
@@ -214,16 +221,7 @@ describe('protobufjs-loader', function () {
         );
         assert.sameMembers([expectedDefinitionsFile], files);
 
-        /** @type { string } */
-        const declarations = await new Promise((resolve, reject) => {
-          fs.readFile(expectedDefinitionsFile, (readErr, content) => {
-            if (readErr) {
-              reject(readErr);
-            } else {
-              resolve(content.toString());
-            }
-          });
-        });
+        const declarations = await readFileAsString(expectedDefinitionsFile);
 
         // Make sure the main protobufjs import shows up.
         assert.include(
@@ -253,15 +251,7 @@ describe('protobufjs-loader', function () {
         );
         assert.sameMembers([expectedDeclarationFile], files);
 
-        const declarations = await new Promise((resolve, reject) => {
-          fs.readFile(expectedDeclarationFile, (readErr, content) => {
-            if (readErr) {
-              reject(readErr);
-            } else {
-              resolve(content.toString());
-            }
-          });
-        });
+        const declarations = await readFileAsString(expectedDeclarationFile);
         assert.include(declarations, 'public baz: string;');
         assert.include(declarations, 'public static decodeDelimited');
         assert.include(declarations, 'declare namespace testModuleName');
@@ -307,7 +297,7 @@ describe('protobufjs-loader', function () {
           // Wait for the result if necessary.
           const locationStr = await Promise.resolve(location);
 
-          const content = fs.readFileSync(locationStr).toString();
+          const content = await readFileAsString(locationStr);
           assert.include(content, 'class Bar implements IBar');
           return true;
         };
@@ -368,16 +358,7 @@ describe('protobufjs-loader', function () {
           );
           assert.sameMembers([expectedDeclarationFile], files);
 
-          /** @type { string } */
-          const declarations = await new Promise((resolve, reject) => {
-            fs.readFile(expectedDeclarationFile, (readErr, content) => {
-              if (readErr) {
-                reject(readErr);
-              } else {
-                resolve(content.toString());
-              }
-            });
-          });
+          const declarations = await readFileAsString(expectedDeclarationFile);
 
           // Check that declarations from the top-level `import`
           // fixture are present.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -54,11 +54,11 @@ const globPromise = (globStr) =>
 /**
  * Promisified read-file-as-string function for convenience.
  *
- * @type { (path: string | fs.PathLike) => Promise<string> }
+ * @type { (filename: string | fs.PathLike) => Promise<string> }
  */
-const readFileAsString = (path) =>
+const readFileAsString = (filename) =>
   new Promise((resolve, reject) => {
-    fs.readFile(path, (err, content) => {
+    fs.readFile(filename, (err, content) => {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
This improves readability and gives clearer error messages without explicit handling in `catch` blocks for async tests.