### PR TITLE
build: restore release notes generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "^18.0.0",
         "@types/uglify-js": "^3.17.5",
         "chai": "^4.5.0",
-        "conventional-changelog-conventionalcommits": "^10.0.0",
+        "conventional-changelog-conventionalcommits": "^9.0.0",
         "eslint": "^9.39.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-plugin-mocha": "^11.0.0",
@@ -157,15 +157,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@conventional-changelog/template": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
-      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2561,15 +2552,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
-      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^18.0.0",
     "@types/uglify-js": "^3.17.5",
     "chai": "^4.5.0",
-    "conventional-changelog-conventionalcommits": "^10.0.0",
+    "conventional-changelog-conventionalcommits": "^9.0.0",
     "eslint": "^9.39.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-mocha": "^11.0.0",


### PR DESCRIPTION
`conventional-changelog-conventionalcommits` 10 was rewritten on top of `@conventional-changelog/template` and renamed its writer options (mainTemplate became template/preamblePartial), which requires `conventional-changelog-writer 9`. `semantic-release`'s `release-notes-generator` bundles writer 8, which does not recognize the new options and silently renders every section empty, so v4.0.0 was published with nothing but a version header.

Forcing writer 9 does not help: the generator then emits notes without the version header and ignores the hidden types in the preset config. Pin the preset to `^9.0.0` instead, the newest version compatible with the bundled writer.